### PR TITLE
remove unused moto from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ MarkupSafe==3.0.2
 marshmallow==3.23.1
 mccabe==0.7.0
 mdurl==0.1.2
-moto==5.0.20
 mpmath==1.3.0
 multipart==1.1.0
 mypy-extensions==1.0.0


### PR DESCRIPTION
Removal of the Moto library as tests have been refactored to no longer use it.